### PR TITLE
Fix SGWCN model constructors

### DIFF
--- a/evaluate_sgwcn.py
+++ b/evaluate_sgwcn.py
@@ -85,6 +85,7 @@ class SGWCNEvaluator:
             input_dim=config.input_dim,
             hidden_dims=config.hidden_dims,
             num_classes=config.num_classes,
+            num_points=config.num_points,
             num_time_steps=config.num_time_steps,
             k_neighbors=config.k_neighbors,
             chebyshev_order=config.chebyshev_order,

--- a/train_sgwcn.py
+++ b/train_sgwcn.py
@@ -47,6 +47,7 @@ def create_model(config: SGWCNConfig) -> SGWCNClassifier:
         input_dim=config.input_dim,
         hidden_dims=config.hidden_dims,
         num_classes=config.num_classes,
+        num_points=config.num_points,
         num_time_steps=config.num_time_steps,
         k_neighbors=config.k_neighbors,
         chebyshev_order=config.chebyshev_order,


### PR DESCRIPTION
## Summary
- propagate `num_points` to `SGWCNClassifier` when creating models

## Testing
- `python test_imports.py` *(fails: No module named 'torch')*
- `python test_sgwcn.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840eeef738883279b6c499c8fd2d682